### PR TITLE
fix : calendar 경로를 인증필수 경로에서 제외

### DIFF
--- a/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
         // 엔드포인트별 인증인가 정책 설정
         http
                 .authorizeHttpRequests(authorizeHttpRequestCustomizer -> authorizeHttpRequestCustomizer
-                        .requestMatchers("/auth/login", "/users").permitAll()
+                        .requestMatchers("/auth/login", "/users", "/calendar/schedules").permitAll()
                         .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
                         .anyRequest().authenticated()
                 );


### PR DESCRIPTION
* calendar 경로 401오류 해결을 위한 pr입니다