### PR TITLE
fix : 토큰 검증 필터를 Calendar 엔드포인터에서만 적용되도록 수정

### DIFF
--- a/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
@@ -61,6 +61,7 @@ public class SecurityConfig {
 
         // 토큰 검증 필터 추가
         http
+                .securityMatcher("calendar/schedules")
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         http

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       local : local-db, dev-port, common
       dev: dev-db, dev-port, common
       prod: prod-db, prod-port, common
-    active: local
+    active: prod
   mvc:
     throw-exception-if-no-handler-found: true
   web:
@@ -25,7 +25,7 @@ spring:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -64,7 +64,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #이슈넘버

## 작업 내용 📝
- 원래 토큰 검증 필터가 모든 엔드포인트에 대해 적용되었던 것을 수정하여 calendar 경로에만 적용되도록했습니다
- 변경된 서비스 디자인에서는 개인화면을 제외한 메인화면과 메뉴화면 캘린더화면 등은 로그인을 안한 사용자도 접근이 가능해야합니다
- 따라서 토큰 검증필터는 calendar/schedules 경로에만 적용합니다 -> Calendar에서는 로그인한 사용자인 경우에는 해당 사용자가 저장한 개인일정까지 보여줄수 있어야하기 때문입니다
- 위의 변경작업 수행 후, 현재는 중복된 아이디로 회원가입 시 올바른 오류코드가 전송되어 클라이언트 화면에 오류 메시지 팝업 표시가 잘 작동됩니다

## 미해결 작업😅
- [ ] Task1

## 전달사항 📢
