### PR TITLE
fix : LoginFailedException과 SameUserExistsException 클래스가 BadRequestException을 상속받도록 수정

### DIFF
--- a/src/main/java/com/runningmate/server/domain/auth/exception/LoginFailedException.java
+++ b/src/main/java/com/runningmate/server/domain/auth/exception/LoginFailedException.java
@@ -1,15 +1,16 @@
 package com.runningmate.server.domain.auth.exception;
 
+import com.runningmate.server.global.common.exception.BadRequestException;
 import com.runningmate.server.global.common.response.status.ResponseStatus;
 import lombok.Getter;
 
 @Getter
-public class LoginFailedException extends RuntimeException {
+public class LoginFailedException extends BadRequestException {
 
     private final ResponseStatus exceptionStatus;
 
     public LoginFailedException(ResponseStatus exceptionStatus) {
-        super(exceptionStatus.getMessage());
+        super(exceptionStatus);
         this.exceptionStatus = exceptionStatus;
     }
 }

--- a/src/main/java/com/runningmate/server/domain/user/exception/SameUserExistsException.java
+++ b/src/main/java/com/runningmate/server/domain/user/exception/SameUserExistsException.java
@@ -1,15 +1,16 @@
 package com.runningmate.server.domain.user.exception;
 
+import com.runningmate.server.global.common.exception.BadRequestException;
 import com.runningmate.server.global.common.response.status.ResponseStatus;
 import lombok.Getter;
 
 @Getter
-public class SameUserExistsException extends RuntimeException {
+public class SameUserExistsException extends BadRequestException {
 
     private final ResponseStatus exceptionStatus;
 
     public SameUserExistsException(ResponseStatus exceptionStatus) {
-        super(exceptionStatus.getMessage());
+        super(exceptionStatus);
         this.exceptionStatus = exceptionStatus;
     }
 }

--- a/src/main/java/com/runningmate/server/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/runningmate/server/global/common/exception_handler/GlobalControllerAdvice.java
@@ -2,6 +2,7 @@ package com.runningmate.server.global.common.exception_handler;
 
 import com.runningmate.server.global.common.exception.BadRequestException;
 import com.runningmate.server.global.common.response.BaseErrorResponse;
+import com.runningmate.server.global.common.response.BaseErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #이슈넘버

## 작업 내용 📝
- 로그인과 회원가입 실패시 계속해서 클라쪽으로 50000번 runtime error code가 오는것을 수정하기위해, 원래 LoginFailedException과 SameUserExistsException 클래스가 RunTimeException을 상속받는것을 수정하여 BadRequestException을 상속받도록 수정하였습니다
- 이렇게 하면 에러처리 클래스인 GlobalControllerAdvice에서 로그인, 회원가입 에러가 handle_RuntimeException쪽으로 빠지는것을 방지할수 있습니다

## 미해결 작업😅
- [ ] Task1

## 전달사항 📢
