### PR TITLE
fix : global error handler와 domain specific error handler 중 domain이 더…

### DIFF
--- a/src/main/java/com/runningmate/server/domain/auth/exception_handler/AuthControllerAdvice.java
+++ b/src/main/java/com/runningmate/server/domain/auth/exception_handler/AuthControllerAdvice.java
@@ -4,6 +4,8 @@ import com.runningmate.server.domain.auth.exception.LoginFailedException;
 import com.runningmate.server.domain.user.exception.SameUserExistsException;
 import com.runningmate.server.global.common.response.BaseErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -14,6 +16,7 @@ import static com.runningmate.server.global.common.response.status.BaseException
 
 @Slf4j
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class AuthControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(LoginFailedException.class)

--- a/src/main/java/com/runningmate/server/domain/user/exception_handler/UserControllerAdvice.java
+++ b/src/main/java/com/runningmate/server/domain/user/exception_handler/UserControllerAdvice.java
@@ -3,6 +3,8 @@ package com.runningmate.server.domain.user.exception_handler;
 import com.runningmate.server.domain.user.exception.SameUserExistsException;
 import com.runningmate.server.global.common.response.BaseErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -12,6 +14,7 @@ import static com.runningmate.server.global.common.response.status.BaseException
 
 @Slf4j
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class UserControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(SameUserExistsException.class)


### PR DESCRIPTION
… 우선순위가 높도록 수정

## 관련 이슈 🛠
- closed #이슈넘버
- 스프링은 여러 @RestControllerAdvice가 있을 때 @Order 값(낮을수록 우선) → 그다음 Advice 등록 순서(클래스 경로 스캔 순)을 기준으로 “가장 먼저 매칭되는 Advice 하나”만 사용함
- 두 Advice 모두 @Order를 지정하지 않았기 때문에, JAR 빌드·패키징 과정에서 클래스 로딩 순서가 달라지면서 
로컬: Auth → Global
배포: Global → Auth
순으로 환경에 따라 적용되는 error handler가 달라지는 문제 발생 (한 번 핸들러 선택되면 다른 핸들러는 적용되지 x)

## 작업 내용 📝
- @Order(Ordered.HIGHEST_PRECEDENCE) 어노테이션을 추가하여 domain specific error handler에 우선순위 부여

## 미해결 작업😅
- [ ] Task1

## 전달사항 📢
