### PR TITLE
fix : JwtAuthenticationFilter와 LoginUserIdArgumentResolver 수정으로 userId가 null이어도 calendar 접근 가능토록 변경

### DIFF
--- a/src/main/java/com/runningmate/server/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/runningmate/server/domain/calendar/service/CalendarService.java
@@ -27,7 +27,12 @@ public class CalendarService {
     private final UserRepository userRepository;
     private final ScheduleRepository scheduleRepository;
     public GetSchedulesResponse findSchedules(Long userId, Integer year) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+        User user;
+        if (userId != null) {
+            user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+        } else {
+            user = null;
+        }
         List<SchedulesForDate> dates = new ArrayList<>();
         IntStream.range(1, 13)
                 .forEach(month -> {

--- a/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
         // 엔드포인트별 인증인가 정책 설정
         http
                 .authorizeHttpRequests(authorizeHttpRequestCustomizer -> authorizeHttpRequestCustomizer
-                        .requestMatchers("/auth/login", "/users", "/calendar/schedules").permitAll()
+                        .requestMatchers("/auth/login", "/users", "/calendar/schedules/**").permitAll()
                         .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/runningmate/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/runningmate/server/global/jwt/JwtAuthenticationFilter.java
@@ -44,9 +44,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             //스프링 시큐리티 인증 토큰 생성하고 세션에 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
 
+
+        }
         filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getRequestURI().equals("calendar/schedules");
     }
 
     private static String extractToken(HttpServletRequest request) {

--- a/src/main/java/com/runningmate/server/global/jwt/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/runningmate/server/global/jwt/LoginUserIdArgumentResolver.java
@@ -25,6 +25,11 @@ public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolve
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String token = (String) request.getAttribute("access_token");
+        if (token == null || token.isBlank()) {
+            // 토큰이 없는 요청이면 null 을 반환하거나,
+            // 0L 등의 기본값을 반환해도 됨 (컨트롤러에서 null 체크)
+            return null;
+        }
         Long userId = jwtUtil.getUserId(token);
         log.info("[resolveArgument] userId = {}", userId);
         return userId;


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #이슈넘버

## 작업 내용 📝
- 기존에 프런트쪽에서 access token이 없는 경우 null값을 보내는데, 이 값이 백엔드쪽에서는 문자열로 "null"로 인식되어서 오류가 있었는데 프런트쪽에서 이것을 수정함
- CalendarController에서 @LoginUserId 어노테이션을 사용해서 LoginUserIdArgumentResolver 클래스의 resolveArgument 메서드가 호출되었는데, 여기서 jwtUtil.getUserId(token) 이 코드에서 token이 null이라 오류가 나기때문에 예외처리를 해주었다
- JwtAuthenticationFilter에 shouldNotFilter 메서드를 추가해 calendar 경로에서는 토큰 검증을 하지 않도록 변경하였다

## 미해결 작업😅
- 현재 캘린더 페이지 접속 가능하나, 일정들은 보이지 않는다 -> 일정들이 보이도록 해야함

## 전달사항 📢
