### PR TITLE
fix : 주기적으로 스크랩한 뉴스 데이터를 캐시하여 제공하도록 변경

### DIFF
--- a/src/main/java/com/runningmate/server/ServerApplication.java
+++ b/src/main/java/com/runningmate/server/ServerApplication.java
@@ -4,13 +4,15 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class ServerApplication {
 
     public static void main(String[] args) {
-        WebDriverManager.chromedriver().browserVersion("126").setup();
+        WebDriverManager.chromedriver().clearResolutionCache().setup();
         SpringApplication.run(ServerApplication.class, args);
     }
 

--- a/src/main/java/com/runningmate/server/domain/news/cache/NewsCache.java
+++ b/src/main/java/com/runningmate/server/domain/news/cache/NewsCache.java
@@ -1,0 +1,26 @@
+package com.runningmate.server.domain.news.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.runningmate.server.domain.news.model.NewsItem;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Component
+public class NewsCache {
+
+    private final AtomicReference<List<NewsItem>> cache = new AtomicReference<>(Collections.emptyList());
+//    private final ObjectMapper mapper = new ObjectMapper();
+//    private final Path jsonPath = Path.of("/app/data/news_data.json");
+
+    public List<NewsItem> getCache() {
+        return cache.get();
+    }
+
+    public void setCache(List<NewsItem> news) {
+        cache.set(news);
+    }
+}

--- a/src/main/java/com/runningmate/server/domain/news/controller/NewsController.java
+++ b/src/main/java/com/runningmate/server/domain/news/controller/NewsController.java
@@ -1,5 +1,6 @@
 package com.runningmate.server.domain.news.controller;
 
+import com.runningmate.server.domain.news.cache.NewsCache;
 import com.runningmate.server.domain.news.service.NewsService;
 import com.runningmate.server.global.common.response.BaseResponse;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,9 +12,14 @@ import java.util.Map;
 @RestController
 public class NewsController {
 
+    private final NewsCache cache;
+
+    public NewsController(NewsCache cache) {
+        this.cache = cache;
+    }
+
     @GetMapping("/news")
     public BaseResponse<Object> getNews() {
-        List<Map<String, String>> news = NewsService.scrapeNews();
-        return new BaseResponse<>(news);
+        return new BaseResponse<>(cache.getCache());
     }
 }

--- a/src/main/java/com/runningmate/server/domain/news/model/NewsItem.java
+++ b/src/main/java/com/runningmate/server/domain/news/model/NewsItem.java
@@ -1,0 +1,4 @@
+package com.runningmate.server.domain.news.model;
+
+public record NewsItem(String title, String link, String image) {
+}

--- a/src/main/java/com/runningmate/server/domain/news/schedule/NewsScheduler.java
+++ b/src/main/java/com/runningmate/server/domain/news/schedule/NewsScheduler.java
@@ -1,0 +1,34 @@
+package com.runningmate.server.domain.news.schedule;
+
+import com.runningmate.server.domain.news.cache.NewsCache;
+import com.runningmate.server.domain.news.service.NewsService;
+import jakarta.annotation.PostConstruct;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NewsScheduler {
+
+    private final NewsService newsService;
+    private final NewsCache cache;
+
+    public NewsScheduler(NewsService newsService, NewsCache cache) {
+        this.newsService = newsService;
+        this.cache = cache;
+    }
+
+    @PostConstruct
+    public void firstLoad() {
+        refresh();
+    }
+
+    @Scheduled(fixedRate = 1 * 60 * 1000)
+    public void refresh() {
+        try {
+            cache.setCache(newsService.scrapeNews());
+            System.out.println("뉴스 캐시 갱신 완료");
+        } catch (Exception e) {
+            System.err.println("뉴스 캐시 갱신 중 오류 발생: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/runningmate/server/domain/news/service/NewsService.java
+++ b/src/main/java/com/runningmate/server/domain/news/service/NewsService.java
@@ -1,5 +1,6 @@
 package com.runningmate.server.domain.news.service;
 
+import com.runningmate.server.domain.news.model.NewsItem;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -19,10 +20,13 @@ import java.util.Map;
 @Service
 public class NewsService {
 
-    public static List<Map<String, String>> scrapeNews() {
+    public static List<NewsItem> scrapeNews() {
 
         ChromeOptions options = new ChromeOptions();
-        options.setBinary("/usr/bin/chromium-browser");
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("linux")) {
+            options.setBinary("/usr/bin/chromium-browser");    // 컨테이너에서만 필요
+        }
         options.addArguments("--headless");
         options.addArguments("--no-sandbox");
         options.addArguments("--disable-dev-shm-usage");
@@ -36,7 +40,7 @@ public class NewsService {
                 .build();
 
         WebDriver driver = new ChromeDriver(service, options);
-        List<Map<String, String>> newsList = new ArrayList<>();
+        List<NewsItem> newsList = new ArrayList<>();
 
         try {
             driver.get("https://news.naver.com/section/100");
@@ -47,19 +51,14 @@ public class NewsService {
                     ));
 
             List<WebElement> links = driver.findElements(By.cssSelector(".sa_text > a"));
-            List<WebElement> headlines = driver.findElements(By.cssSelector(".sa_text_strong"));
+            List<WebElement> titles = driver.findElements(By.cssSelector(".sa_text_strong"));
             List<WebElement> imgs = driver.findElements(By.cssSelector(".section_article img"));
 
-            for (int i = 0; i < headlines.size(); i++) {
-                String title = headlines.get(i).getText();
-                String link = links.get(i).getAttribute("href");
-                String imgUrl = imgs.get(i).getAttribute("src");
-
-                Map<String, String> newsItem = new HashMap<>();
-                newsItem.put("title", title);
-                newsItem.put("link", link);
-                newsItem.put("image", imgUrl);  // 로컬 저장 안하고 URL 그대로 사용
-                newsList.add(newsItem);
+            for (int i = 0; i < titles.size(); i++) {
+                newsList.add(new NewsItem(
+                        titles.get(i).getText(),
+                        links.get(i).getAttribute("href"),
+                        imgs.get(i).getAttribute("src")));
             }
 
 //            System.out.println("✅ news_data.json 저장 완료");


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #이슈넘버

## 작업 내용 📝
- 서버에 요청할때마다 스크래핑을 하는 방식에서, 서버가 뉴스데이터를 주기적으로 스크랩하여 캐싱해두고 그 캐시데이터를 클라이언트 요청시 전달해주는 방식으로 로직을 수정하였습니다

## 미해결 작업😅
- [ ] Task1

## 전달사항 📢
