### PR TITLE
[Feat] 댓글 공감 기능 구현

### DIFF
--- a/src/main/java/com/runningmate/server/domain/community/controller/CommentController.java
+++ b/src/main/java/com/runningmate/server/domain/community/controller/CommentController.java
@@ -19,7 +19,7 @@ public class CommentController {
     private final CommentService commentService;
     @PostMapping("/{commentId}/likes")
     public BaseResponse<LikeCommentResponse> likeComment(@LoginUserId Long userId, @PathVariable Long commentId){
-        log.info("[likeComment] userId = {}, commentId = {}");
+        log.info("[likeComment] userId = {}, commentId = {}", userId, commentId);
         return new BaseResponse<>(commentService.likeComment(userId, commentId));
     }
 }

--- a/src/main/java/com/runningmate/server/domain/community/controller/CommentController.java
+++ b/src/main/java/com/runningmate/server/domain/community/controller/CommentController.java
@@ -1,0 +1,11 @@
+package com.runningmate.server.domain.community.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequestMapping("comments")
+@RestController
+public class CommentController {
+}

--- a/src/main/java/com/runningmate/server/domain/community/controller/CommentController.java
+++ b/src/main/java/com/runningmate/server/domain/community/controller/CommentController.java
@@ -1,11 +1,25 @@
 package com.runningmate.server.domain.community.controller;
 
+import com.runningmate.server.domain.community.dto.LikeCommentResponse;
+import com.runningmate.server.domain.community.service.CommentService;
+import com.runningmate.server.global.common.response.BaseResponse;
+import com.runningmate.server.global.jwt.LoginUserId;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@RequiredArgsConstructor
 @RequestMapping("comments")
 @RestController
 public class CommentController {
+    private final CommentService commentService;
+    @PostMapping("/{commentId}/likes")
+    public BaseResponse<LikeCommentResponse> likeComment(@LoginUserId Long userId, @PathVariable Long commentId){
+        log.info("[likeComment] userId = {}, commentId = {}");
+        return new BaseResponse<>(commentService.likeComment(userId, commentId));
+    }
 }

--- a/src/main/java/com/runningmate/server/domain/community/controller/PostController.java
+++ b/src/main/java/com/runningmate/server/domain/community/controller/PostController.java
@@ -47,9 +47,9 @@ public class PostController {
     }
 
     @GetMapping("/{postId}/comments")
-    public BaseResponse<GetPostCommentsReponse> getPostComments(@PathVariable Long postId){
-        log.info("[getPostComments] postId = {}", postId);
-        return new BaseResponse<>(postCommentService.findByPostId(postId));
+    public BaseResponse<GetPostCommentsReponse> getPostComments(@LoginUserId Long userId, @PathVariable Long postId){
+        log.info("[getPostComments] userId = {}, postId = {}", userId, postId);
+        return new BaseResponse<>(postCommentService.findComments(userId, postId));
     }
 
     @PostMapping("/{postId}/likes")

--- a/src/main/java/com/runningmate/server/domain/community/controller/PostController.java
+++ b/src/main/java/com/runningmate/server/domain/community/controller/PostController.java
@@ -53,10 +53,9 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/likes")
-    public BaseResponse<Void> likePost(@LoginUserId Long userId, @PathVariable Long postId){
+    public BaseResponse<LikePostResponse> likePost(@LoginUserId Long userId, @PathVariable Long postId){
         log.info("[likePost] userId = {} postId = {}", userId, postId);
-        postService.likePost(userId, postId);
-        return new BaseResponse<>(null);
+        return new BaseResponse<>(postService.likePost(userId, postId));
     }
 }
 

--- a/src/main/java/com/runningmate/server/domain/community/dto/CommentResponse.java
+++ b/src/main/java/com/runningmate/server/domain/community/dto/CommentResponse.java
@@ -17,17 +17,15 @@ public record CommentResponse(
         Boolean hasLiked,
         List<ReplyResponse> replies
 ) {
-    public static CommentResponse entityToDto(Comment comment){
+    public static CommentResponse entityToDto(Comment comment, boolean hasLiked, List<ReplyResponse> replies){
         return CommentResponse.builder()
                 .commentId(comment.getId())
                 .createdAt(comment.getCreatedAt())
                 .writer(comment.getIsAnonymous() ? "익명" : comment.getWriter().getNickname())
                 .content(comment.getContent())
                 .likeCount(comment.getLikeCount())
-                .hasLiked(false)
-                .replies(comment.getChildren().stream()
-                        .map(ReplyResponse::entityToDto)
-                        .collect(Collectors.toList()))
+                .hasLiked(hasLiked)
+                .replies(replies)
                 .build();
     }
 }

--- a/src/main/java/com/runningmate/server/domain/community/dto/GetPostCommentsReponse.java
+++ b/src/main/java/com/runningmate/server/domain/community/dto/GetPostCommentsReponse.java
@@ -8,9 +8,4 @@ import java.util.stream.Collectors;
 public record GetPostCommentsReponse(
     List<CommentResponse> comments
 ) {
-    public static GetPostCommentsReponse createFromEntityList(List<Comment> comments){
-        return new GetPostCommentsReponse(comments.stream()
-                .map(CommentResponse::entityToDto)
-                .collect(Collectors.toList()));
-    }
 }

--- a/src/main/java/com/runningmate/server/domain/community/dto/LikeCommentResponse.java
+++ b/src/main/java/com/runningmate/server/domain/community/dto/LikeCommentResponse.java
@@ -1,0 +1,6 @@
+package com.runningmate.server.domain.community.dto;
+
+public record LikeCommentResponse(
+        Long likes
+) {
+}

--- a/src/main/java/com/runningmate/server/domain/community/dto/LikePostResponse.java
+++ b/src/main/java/com/runningmate/server/domain/community/dto/LikePostResponse.java
@@ -1,0 +1,6 @@
+package com.runningmate.server.domain.community.dto;
+
+public record LikePostResponse(
+        Long likes
+) {
+}

--- a/src/main/java/com/runningmate/server/domain/community/dto/ReplyResponse.java
+++ b/src/main/java/com/runningmate/server/domain/community/dto/ReplyResponse.java
@@ -14,14 +14,14 @@ public record ReplyResponse(
         Long likeCount,
         Boolean hasLiked
 ) {
-    public static ReplyResponse entityToDto(Comment comment){
+    public static ReplyResponse entityToDto(Comment reply, boolean hasLiked){
         return ReplyResponse.builder()
-                .commentId(comment.getId())
-                .createdAt(comment.getCreatedAt())
-                .writer(comment.getIsAnonymous() ? "익명 " : comment.getWriter().getNickname())
-                .content(comment.getContent())
-                .likeCount(comment.getLikeCount())
-                .hasLiked(false)
+                .commentId(reply.getId())
+                .createdAt(reply.getCreatedAt())
+                .writer(reply.getIsAnonymous() ? "익명 " : reply.getWriter().getNickname())
+                .content(reply.getContent())
+                .likeCount(reply.getLikeCount())
+                .hasLiked(hasLiked)
                 .build();
     }
 }

--- a/src/main/java/com/runningmate/server/domain/community/model/Comment.java
+++ b/src/main/java/com/runningmate/server/domain/community/model/Comment.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.SQLRestriction;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.WRITER_NOT_ALLOWED_TO_ADD_LIKE;
+import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.LIKE_NOT_ALLOWED_TO_WRITER;
 
 @Getter
 @Builder
@@ -68,7 +68,7 @@ public class Comment extends BaseEntity {
 
     public CommentLike addLike(User user) {
         if(this.writer == user){
-            throw new BadRequestException(WRITER_NOT_ALLOWED_TO_ADD_LIKE);
+            throw new BadRequestException(LIKE_NOT_ALLOWED_TO_WRITER);
         }
 
         this.likeCount++;

--- a/src/main/java/com/runningmate/server/domain/community/model/Comment.java
+++ b/src/main/java/com/runningmate/server/domain/community/model/Comment.java
@@ -1,6 +1,7 @@
 package com.runningmate.server.domain.community.model;
 
 import com.runningmate.server.domain.user.model.User;
+import com.runningmate.server.global.common.exception.BadRequestException;
 import com.runningmate.server.global.common.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,8 @@ import org.hibernate.annotations.SQLRestriction;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.WRITER_NOT_ALLOWED_TO_ADD_LIKE;
 
 @Getter
 @Builder
@@ -61,5 +64,18 @@ public class Comment extends BaseEntity {
 
     public boolean isParent(){
         return this.parent == null;
+    }
+
+    public CommentLike addLike(User user) {
+        if(this.writer == user){
+            throw new BadRequestException(WRITER_NOT_ALLOWED_TO_ADD_LIKE);
+        }
+
+        this.likeCount++;
+
+        return CommentLike.builder()
+                .comment(this)
+                .user(user)
+                .build();
     }
 }

--- a/src/main/java/com/runningmate/server/domain/community/model/CommentLike.java
+++ b/src/main/java/com/runningmate/server/domain/community/model/CommentLike.java
@@ -1,0 +1,23 @@
+package com.runningmate.server.domain.community.model;
+
+import com.runningmate.server.domain.user.model.User;
+import com.runningmate.server.global.common.model.BaseEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "user_id", "comment_id"})
+})
+public class CommentLike extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+}

--- a/src/main/java/com/runningmate/server/domain/community/model/CommentLike.java
+++ b/src/main/java/com/runningmate/server/domain/community/model/CommentLike.java
@@ -3,7 +3,13 @@ package com.runningmate.server.domain.community.model;
 import com.runningmate.server.domain.user.model.User;
 import com.runningmate.server.global.common.model.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(uniqueConstraints = {
         @UniqueConstraint(columnNames = { "user_id", "comment_id"})

--- a/src/main/java/com/runningmate/server/domain/community/model/Post.java
+++ b/src/main/java/com/runningmate/server/domain/community/model/Post.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.SQLRestriction;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.WRITER_NOT_ALLOWED_TO_ADD_LIKE;
+import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.LIKE_NOT_ALLOWED_TO_WRITER;
 
 @Getter
 @Builder
@@ -61,7 +61,7 @@ public class Post extends BaseEntity {
 
     public PostLike addLike(User user) {
         if(user == writer){
-            throw new BadRequestException(WRITER_NOT_ALLOWED_TO_ADD_LIKE);
+            throw new BadRequestException(LIKE_NOT_ALLOWED_TO_WRITER);
         }
 
         this.likeCount++;

--- a/src/main/java/com/runningmate/server/domain/community/repository/CommentLikeRepository.java
+++ b/src/main/java/com/runningmate/server/domain/community/repository/CommentLikeRepository.java
@@ -1,0 +1,9 @@
+package com.runningmate.server.domain.community.repository;
+
+import com.runningmate.server.domain.community.model.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+}

--- a/src/main/java/com/runningmate/server/domain/community/repository/CommentLikeRepository.java
+++ b/src/main/java/com/runningmate/server/domain/community/repository/CommentLikeRepository.java
@@ -1,9 +1,12 @@
 package com.runningmate.server.domain.community.repository;
 
+import com.runningmate.server.domain.community.model.Comment;
 import com.runningmate.server.domain.community.model.CommentLike;
+import com.runningmate.server.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    boolean existsByUserAndComment(User user, Comment comment);
 }

--- a/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
@@ -9,6 +9,7 @@ import com.runningmate.server.domain.community.repository.CommentRepository;
 import com.runningmate.server.domain.user.model.User;
 import com.runningmate.server.domain.user.repository.UserRepository;
 import com.runningmate.server.global.common.exception.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import static com.runningmate.server.global.common.response.status.BaseException
 
 @Slf4j
 @AllArgsConstructor
+@Transactional
 @Service
 public class CommentService {
     private final UserRepository userRepository;

--- a/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
@@ -1,0 +1,10 @@
+package com.runningmate.server.domain.community.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class CommentService {
+
+}

--- a/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
@@ -1,10 +1,43 @@
 package com.runningmate.server.domain.community.service;
 
+import com.runningmate.server.domain.community.dto.LikeCommentResponse;
+import com.runningmate.server.domain.community.exception.AlreadyLikedException;
+import com.runningmate.server.domain.community.model.Comment;
+import com.runningmate.server.domain.community.model.CommentLike;
+import com.runningmate.server.domain.community.repository.CommentLikeRepository;
+import com.runningmate.server.domain.community.repository.CommentRepository;
+import com.runningmate.server.domain.user.model.User;
+import com.runningmate.server.domain.user.repository.UserRepository;
+import com.runningmate.server.global.common.exception.EntityNotFoundException;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.*;
+
 @Slf4j
+@AllArgsConstructor
 @Service
 public class CommentService {
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    public LikeCommentResponse likeComment(Long userId, Long commentId) {
+        log.info("[likeComment]");
 
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new EntityNotFoundException(COMMENT_NOT_FOUND));
+
+        // 이미 공감한 댓글은 다시 공감할 수 없음
+        if(commentLikeRepository.existsByUserAndComment(user, comment)){
+            throw new AlreadyLikedException(ALREADY_LIKED_POST);
+        }
+
+        CommentLike commentLike = comment.addLike(user);
+
+        commentLikeRepository.save(commentLike);
+
+        return new LikeCommentResponse(comment.getLikeCount());
+    }
 }

--- a/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/CommentService.java
@@ -31,7 +31,7 @@ public class CommentService {
 
         // 이미 공감한 댓글은 다시 공감할 수 없음
         if(commentLikeRepository.existsByUserAndComment(user, comment)){
-            throw new AlreadyLikedException(ALREADY_LIKED_POST);
+            throw new AlreadyLikedException(ALREADY_LIKED_COMMENT);
         }
 
         CommentLike commentLike = comment.addLike(user);

--- a/src/main/java/com/runningmate/server/domain/community/service/PostCommentService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/PostCommentService.java
@@ -1,9 +1,12 @@
 package com.runningmate.server.domain.community.service;
 
+import com.runningmate.server.domain.community.dto.CommentResponse;
 import com.runningmate.server.domain.community.dto.CreateCommentOnPostRequest;
 import com.runningmate.server.domain.community.dto.GetPostCommentsReponse;
+import com.runningmate.server.domain.community.dto.ReplyResponse;
 import com.runningmate.server.domain.community.model.Comment;
 import com.runningmate.server.domain.community.model.Post;
+import com.runningmate.server.domain.community.repository.CommentLikeRepository;
 import com.runningmate.server.domain.community.repository.CommentRepository;
 import com.runningmate.server.domain.community.repository.PostRepository;
 import com.runningmate.server.domain.user.model.User;
@@ -13,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,17 +30,44 @@ public class PostCommentService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
-    public GetPostCommentsReponse findByPostId(Long postId) {
+    public GetPostCommentsReponse findComments(Long userId, Long postId) {
+        log.info("[findComments]");
+        User user = null;
+
+        // 로그인한 사용자인 경우 조회
+        if(userId != null) {
+            user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        }
+
         // 게시물 조회
         Post post = postRepository.findById(postId).orElseThrow(() -> new EntityNotFoundException(POST_NOT_FOUND));
 
         // 댓글을 DTO로 변환
-        List<Comment> comments = post.getComments();
+        List<Comment> parents = post.getComments().stream()
+                .sorted(Comparator.comparing(Comment::getCreatedAt))
+                .filter(Comment::isParent).collect(Collectors.toList());
 
-        List<Comment> parents = comments.stream().filter(Comment::isParent).collect(Collectors.toList());
+        List<CommentResponse> commentResponses = new ArrayList<>();
+        for(Comment comment : parents){
+            List<ReplyResponse> replyResponses = new ArrayList<>();
+            List<Comment> children = comment.getChildren().stream()
+                    .sorted(Comparator.comparing(Comment::getCreatedAt))
+                    .collect(Collectors.toList());
+            for(Comment reply : children){
+                ReplyResponse replyResponse = ReplyResponse.entityToDto(reply, hasUserLikedComment(user, reply));
+                replyResponses.add(replyResponse);
+            }
+            CommentResponse commentResponse = CommentResponse.entityToDto(comment, hasUserLikedComment(user, comment), replyResponses);
+            commentResponses.add(commentResponse);
+        }
 
-        return GetPostCommentsReponse.createFromEntityList(parents);
+        return new GetPostCommentsReponse(commentResponses);
+    }
+
+    private boolean hasUserLikedComment(User user, Comment reply) {
+        return user == null ? false : commentLikeRepository.existsByUserAndComment(user, reply);
     }
 
     public long createComment(Long userId, Long postId, CreateCommentOnPostRequest request) {

--- a/src/main/java/com/runningmate/server/domain/community/service/PostService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/PostService.java
@@ -115,7 +115,7 @@ public class PostService {
         return GetPostResponse.entityToDto(post, hasLiked);
     }
 
-    public void likePost(Long userId, Long postId) {
+    public LikePostResponse likePost(Long userId, Long postId) {
         log.info("[likePost]");
 
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
@@ -129,5 +129,7 @@ public class PostService {
         PostLike postLike = post.addLike(user);
 
         postLikeRepository.save(postLike);
+
+        return new LikePostResponse(post.getLikeCount());
     }
 }

--- a/src/main/java/com/runningmate/server/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/runningmate/server/global/common/exception_handler/GlobalControllerAdvice.java
@@ -20,9 +20,9 @@ import static com.runningmate.server.global.common.response.status.BaseException
 public class GlobalControllerAdvice {
     // 잘못된 요청일 경우
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler({BadRequestException.class, TypeMismatchException.class})
-    public BaseErrorResponse handle_BadRequest(Exception e){
-        log.error("[handle_BadRequest]", e);
+    @ExceptionHandler(TypeMismatchException.class)
+    public BaseErrorResponse handle_TypeMismatchException(TypeMismatchException e){
+        log.error("[handle_TypeMismatchException]", e);
         return new BaseErrorResponse(BAD_REQUEST);
     }
 
@@ -64,6 +64,14 @@ public class GlobalControllerAdvice {
     @ExceptionHandler(CustomException.class)
     public BaseErrorResponse handle_CustomException(CustomException e) {
         log.error("[handle_CustomException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus());
+    }
+
+    // 허용되지 않은 요청 파라미터인 경우
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BadRequestException.class)
+    public BaseErrorResponse handle_BadRequestException(BadRequestException e){
+        log.error("[handle_BadRequestException]", e);
         return new BaseErrorResponse(e.getExceptionStatus());
     }
 }

--- a/src/main/java/com/runningmate/server/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/runningmate/server/global/common/response/status/BaseExceptionResponseStatus.java
@@ -43,7 +43,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     POST_NOT_FOUND(40400, "존재하지 않는 게시글입니다"),
     COMMENT_NOT_FOUND(40400, "존재하지 않는 댓글입니다"),
     WRITER_NOT_ALLOWED_TO_ADD_LIKE(40000, "작성자는 자신의 글에 공감을 추가할 수 없습니다"),
-    ALREADY_LIKED_POST(40000, "이미 공감을 누른 게시글입니다.");
+    ALREADY_LIKED_POST(40000, "이미 공감을 누른 게시글입니다."),
+    ALREADY_LIKED_COMMENT(40000, "이미 공감을 누른 댓글입니다.");;
 
 
     private final boolean success = false;

--- a/src/main/java/com/runningmate/server/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/runningmate/server/global/common/response/status/BaseExceptionResponseStatus.java
@@ -42,7 +42,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     // 게시글 관련 에러
     POST_NOT_FOUND(40400, "존재하지 않는 게시글입니다"),
     COMMENT_NOT_FOUND(40400, "존재하지 않는 댓글입니다"),
-    WRITER_NOT_ALLOWED_TO_ADD_LIKE(40000, "작성자는 자신의 글에 공감을 추가할 수 없습니다"),
+    LIKE_NOT_ALLOWED_TO_WRITER(40000, "작성자는 자신의 글에 공감을 추가할 수 없습니다"),
     ALREADY_LIKED_POST(40000, "이미 공감을 누른 게시글입니다."),
     ALREADY_LIKED_COMMENT(40000, "이미 공감을 누른 댓글입니다.");;
 

--- a/src/main/java/com/runningmate/server/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/runningmate/server/global/common/response/status/BaseExceptionResponseStatus.java
@@ -44,7 +44,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     COMMENT_NOT_FOUND(40400, "존재하지 않는 댓글입니다"),
     LIKE_NOT_ALLOWED_TO_WRITER(40000, "작성자는 자신의 글에 공감을 추가할 수 없습니다"),
     ALREADY_LIKED_POST(40000, "이미 공감을 누른 게시글입니다."),
-    ALREADY_LIKED_COMMENT(40000, "이미 공감을 누른 댓글입니다.");;
+    ALREADY_LIKED_COMMENT(40000, "이미 공감을 누른 댓글입니다.");
 
 
     private final boolean success = false;

--- a/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
@@ -70,7 +70,8 @@ public class SecurityConfig {
 
                     // 비회원도 사용할 수 있도록 GET 요청에 대해서 허용
                     authorize.requestMatchers(HttpMethod.GET, "/posts").permitAll()
-                            .requestMatchers(HttpMethod.GET, "/posts/*").permitAll();
+                            .requestMatchers(HttpMethod.GET, "/posts/*").permitAll()
+                            .requestMatchers(HttpMethod.GET, "/posts/*/comments").permitAll();
 
                     authorize.anyRequest().authenticated();
                 });

--- a/src/test/java/com/runningmate/server/domain/community/controller/PostControllerTest.java
+++ b/src/test/java/com/runningmate/server/domain/community/controller/PostControllerTest.java
@@ -4,6 +4,7 @@ import com.runningmate.server.domain.community.dto.CreateCommentOnPostRequest;
 import com.runningmate.server.domain.community.model.Image;
 import com.runningmate.server.domain.community.model.Post;
 import com.runningmate.server.domain.community.repository.PostRepository;
+import com.runningmate.server.domain.community.service.CommentService;
 import com.runningmate.server.domain.community.service.PostCommentService;
 import com.runningmate.server.domain.community.service.PostService;
 import com.runningmate.server.domain.news.schedule.NewsScheduler;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
+import static java.util.stream.Collectors.toList;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -57,6 +59,9 @@ class PostControllerTest {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private CommentService commentService;
 
     @Autowired
     private EntityManager entityManager;
@@ -186,13 +191,40 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.data.hasLiked").value(false));
     }
 
+    @Test
+    void givenAddLikeToComment_whenGetPostComments_thenHasLikedExists() throws Exception {
+        // given
+        User postWriter = userService.createUser("user1", "pass", "게시글작성자", "asdf@asdf");
+
+        User commentWriter = userService.createUser("user2", "pass", "댓글작성자", "asdf2@asdf");
+
+        Post post = createPostWithImages(postWriter, 2);
+
+        List<Long> commentIdList = LongStream.rangeClosed(1, 2).map(i -> postCommentService.createComment(commentWriter.getId(), post.getId(), CreateCommentOnPostRequest.builder()
+                .content("댓글").isAnonymous(false).parentId(null).build())).boxed().collect(toList());
+
+        commentService.likeComment(postWriter.getId(), commentIdList.get(0));
+
+        // when
+        // then
+        String token = jwtUtil.generateAccessToken(postWriter.getId(), postWriter.getUsername());
+
+        mockMvc.perform(get("/posts/" + post.getId() + "/comments")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.comments[0].likeCount").value(1))
+                .andExpect(jsonPath("$.data.comments[0].hasLiked").value(true))
+                .andExpect(jsonPath("$.data.comments[1].likeCount").value(0))
+                .andExpect(jsonPath("$.data.comments[1].hasLiked").value(false));
+    }
+
     private Post createPostWithImages(User user, int imageCount) {
         List<Image> images = IntStream.rangeClosed(1, imageCount).mapToObj(
                 i -> Image.builder()
                         .imageUrl("image-url" + i)
                         .imageOrder(i)
                         .build()
-        ).collect(Collectors.toList());
+        ).collect(toList());
 
 
         Post post = Post.builder()

--- a/src/test/java/com/runningmate/server/domain/community/service/CommentServiceTest.java
+++ b/src/test/java/com/runningmate/server/domain/community/service/CommentServiceTest.java
@@ -1,0 +1,99 @@
+package com.runningmate.server.domain.community.service;
+
+import com.runningmate.server.domain.community.exception.AlreadyLikedException;
+import com.runningmate.server.domain.community.model.Comment;
+import com.runningmate.server.domain.community.repository.CommentLikeRepository;
+import com.runningmate.server.domain.community.repository.CommentRepository;
+import com.runningmate.server.domain.user.model.User;
+import com.runningmate.server.domain.user.repository.UserRepository;
+import com.runningmate.server.global.common.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.ALREADY_LIKED_COMMENT;
+import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.LIKE_NOT_ALLOWED_TO_WRITER;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+    @InjectMocks
+    private CommentService commentService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @Test
+    void givenCommentAlreadyLiked_whenLikingComment_thenThrowAlreadyLikedException(){
+        // given
+        long userId = 1L;
+        long commentId = 1L;
+
+        User user = createUser(userId);
+        Comment comment = createComment(commentId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentLikeRepository.existsByUserAndComment(user, comment)).thenReturn(true);
+
+        // when
+        Throwable throwable = catchThrowable(() -> commentService.likeComment(userId, commentId));
+
+        // then
+        assertThat(throwable)
+                .isInstanceOf(AlreadyLikedException.class)
+                .hasMessageContaining(ALREADY_LIKED_COMMENT.getMessage());
+    }
+
+    @Test
+    void givenUserWroteComment_whenLikingComment_thenThrowBadRequestException(){
+        // given
+        long userId = 1L;
+        long commentId = 1L;
+
+        User user = createUser(userId);
+        Comment comment = createComment(commentId, user);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentLikeRepository.existsByUserAndComment(user, comment)).thenReturn(false);
+
+        // when
+        Throwable throwable = catchThrowable(() -> commentService.likeComment(userId, commentId));
+
+        // then
+        assertThat(throwable)
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(LIKE_NOT_ALLOWED_TO_WRITER.getMessage());
+    }
+
+    private Comment createComment(long commentId, User user) {
+        return Comment.builder()
+                .id(commentId)
+                .writer(user)
+                .build();
+    }
+
+    private Comment createComment(long commentId) {
+        return Comment.builder()
+                .id(commentId)
+                .build();
+    }
+
+    private User createUser(long userId) {
+        return User.builder()
+                .id(userId)
+                .build();
+    }
+}

--- a/src/test/java/com/runningmate/server/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/runningmate/server/domain/user/repository/UserRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.runningmate.server.user.repository;
+package com.runningmate.server.domain.user.repository;
 
 import com.runningmate.server.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #83

## 작업 내용 📝
- CommentLike엔티티를 추가했습니다
- 게시글 공감 추가 API를 구현했습니다
- 게시글 댓글 목록 조회 시 로그인한 사용자의 댓글 공감 여부가 확인됩니다. 
- BadRequestException의 예외처리를 수정해서 도메인 모델에서 발생하는 예외를 처리하였습니다
- 게시글 공감 추가에서 likes를 반환하지 않는 문제를 수정했습니다
- 댓글 공감과 관련된 테스트 코드를 작성했습니다.
- main의 디렉토리 구조에 맞춰서 테스트 코드의 위치를 수정했습니다

## 미해결 작업😅
- [ ] Task1

## 전달사항 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 댓글에 좋아요를 누를 수 있는 기능이 추가되었습니다.
  * 각 댓글 및 답글에 대해 사용자가 좋아요를 눌렀는지 여부가 표시됩니다.
  * 게시글 좋아요 기능이 좋아요 수를 반환하도록 개선되었습니다.

* **버그 수정**
  * 예외 처리 방식이 개선되어 잘못된 요청에 대해 더 명확한 에러 메시지가 제공됩니다.

* **기타 변경**
  * 게시글의 댓글 목록 조회 시, 로그인한 사용자의 좋아요 여부와 답글 구조가 함께 제공됩니다.
  * 게시글의 댓글 목록은 인증 없이도 조회할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->