### PR TITLE
fix : #86 webdriver 의존성을 위한 라이브러리들 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,13 @@ dependencies {
     // AWS
     implementation platform('software.amazon.awssdk:bom:2.25.8')
     implementation 'software.amazon.awssdk:s3'
+
+    // Spring Boot (버전은 BOM이 관리)
+    implementation platform("org.springframework.boot:spring-boot-dependencies:3.3.8")
+
+    // ⭐ WebDriverManager 6.x 가 필요로 하는 Apache HttpClient5/Core5
+    implementation 'org.apache.httpcomponents.client5:httpclient5'
+    implementation 'org.apache.httpcomponents.core5:httpcore5'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #86 

## 작업 내용 📝
- 작업 내용

## 미해결 작업😅
- [ ] Task1

## 전달사항 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Spring Boot dependencies BOM이 버전 3.3.8로 명시적으로 추가되어 의존성 관리가 일관되게 개선되었습니다.
  * WebDriverManager 6.x 요구사항을 충족하기 위해 Apache HTTP 컴포넌트(httpclient5, httpcore5) 라이브러리가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->