### PR TITLE
[Feat] 홈 화면 조회 API 구현

### DIFF
--- a/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
@@ -19,5 +19,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     """)
     List<Post> findWithKeywordAndCursor(@Param("keyword")String keyword, @Param("lastId") Long lastId, Pageable pageable);
 
-    List<Post> findTop5ByLikeCountGreaterThanOrderByLikeCountDesc(int likeCount);
+    List<Post> findByLikeCountGreaterThanOrderByLikeCountDesc(int likeCount, Pageable pageable);
 }

--- a/src/main/java/com/runningmate/server/domain/community/service/PostService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/PostService.java
@@ -134,6 +134,6 @@ public class PostService {
     }
 
     private List<Post> getTop5PopularPosts() {
-        return postRepository.findTop5ByLikeCountGreaterThanOrderByLikeCountDesc(0);
+        return postRepository.findByLikeCountGreaterThanOrderByLikeCountDesc(0, PageRequest.of(0, 5));
     }
 }

--- a/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
+++ b/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
@@ -1,9 +1,23 @@
 package com.runningmate.server.domain.home.controller;
 
+import com.runningmate.server.domain.home.dto.GetHomeResponse;
+import com.runningmate.server.domain.home.service.HomeService;
+import com.runningmate.server.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@RequiredArgsConstructor
+@RequestMapping("home")
 @RestController
 public class HomeController {
+    private final HomeService homeService;
+    @GetMapping
+    public BaseResponse<GetHomeResponse> getHome(){
+        log.info("[getHome]");
+        return new BaseResponse(homeService.getData());
+    }
 }

--- a/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
+++ b/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
@@ -18,6 +18,6 @@ public class HomeController {
     @GetMapping
     public BaseResponse<GetHomeResponse> getHome(){
         log.info("[getHome]");
-        return new BaseResponse(homeService.getData());
+        return new BaseResponse(homeService.getData(3, 5));
     }
 }

--- a/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
+++ b/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
@@ -1,0 +1,9 @@
+package com.runningmate.server.domain.home.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class HomeController {
+}

--- a/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
+++ b/src/main/java/com/runningmate/server/domain/home/controller/HomeController.java
@@ -18,6 +18,6 @@ public class HomeController {
     @GetMapping
     public BaseResponse<GetHomeResponse> getHome(){
         log.info("[getHome]");
-        return new BaseResponse(homeService.getData(3, 5));
+        return new BaseResponse<>(homeService.getData(3, 5));
     }
 }

--- a/src/main/java/com/runningmate/server/domain/home/dto/GetHomeResponse.java
+++ b/src/main/java/com/runningmate/server/domain/home/dto/GetHomeResponse.java
@@ -1,0 +1,9 @@
+package com.runningmate.server.domain.home.dto;
+
+import java.util.List;
+
+public record GetHomeResponse(
+        List<PopularPoliticianResponse> popularPoliticians,
+        List<PopularPostResponse> popularPostResponses
+) {
+}

--- a/src/main/java/com/runningmate/server/domain/home/dto/PopularPoliticianResponse.java
+++ b/src/main/java/com/runningmate/server/domain/home/dto/PopularPoliticianResponse.java
@@ -1,0 +1,8 @@
+package com.runningmate.server.domain.home.dto;
+
+public record PopularPoliticianResponse (
+        Long politicianId,
+        String name,
+        String imageUrl
+){
+}

--- a/src/main/java/com/runningmate/server/domain/home/dto/PopularPoliticianResponse.java
+++ b/src/main/java/com/runningmate/server/domain/home/dto/PopularPoliticianResponse.java
@@ -1,8 +1,13 @@
 package com.runningmate.server.domain.home.dto;
 
+import com.runningmate.server.domain.politicians.model.Politician;
+
 public record PopularPoliticianResponse (
         Long politicianId,
         String name,
         String imageUrl
 ){
+    public static PopularPoliticianResponse entityToDto(Politician politician) {
+        return new PopularPoliticianResponse(politician.getId(), politician.getName(), politician.getImageUrl());
+    }
 }

--- a/src/main/java/com/runningmate/server/domain/home/dto/PopularPostResponse.java
+++ b/src/main/java/com/runningmate/server/domain/home/dto/PopularPostResponse.java
@@ -1,0 +1,8 @@
+package com.runningmate.server.domain.home.dto;
+
+public record PopularPostResponse(
+        String title,
+        Long likeCount,
+        Long commentCount
+) {
+}

--- a/src/main/java/com/runningmate/server/domain/home/dto/PopularPostResponse.java
+++ b/src/main/java/com/runningmate/server/domain/home/dto/PopularPostResponse.java
@@ -1,8 +1,13 @@
 package com.runningmate.server.domain.home.dto;
 
+import com.runningmate.server.domain.community.model.Post;
+
 public record PopularPostResponse(
         String title,
         Long likeCount,
         Long commentCount
 ) {
+    public static PopularPostResponse entityToDto(Post entity) {
+        return new PopularPostResponse(entity.getTitle(), entity.getLikeCount(), entity.getCommentCount());
+    }
 }

--- a/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
+++ b/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
@@ -1,9 +1,43 @@
 package com.runningmate.server.domain.home.service;
 
+import com.runningmate.server.domain.community.model.Post;
+import com.runningmate.server.domain.community.repository.PostRepository;
+import com.runningmate.server.domain.home.dto.GetHomeResponse;
+import com.runningmate.server.domain.home.dto.PopularPoliticianResponse;
+import com.runningmate.server.domain.home.dto.PopularPostResponse;
+import com.runningmate.server.domain.politicians.model.Politician;
+import com.runningmate.server.domain.politicians.repository.PoliticianRepository;
+import com.runningmate.server.domain.watch.repository.WatchListRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class HomeService {
+    private final WatchListRepository watchListRepository;
+    private final PoliticianRepository politicianRepository;
+    private final PostRepository postRepository;
+    public GetHomeResponse getData(final int politicianSize, final int postSize) {
+        log.info("[getData]");
+
+        // 인기 정치인 조회
+        List<Politician> topPoliticians = watchListRepository.findTopPoliticians(PageRequest.of(0, politicianSize));
+        if(topPoliticians.size() < politicianSize){ // 부족할 경우 랜덤하게 선택된 정치인을 추가
+            List<Politician> randomPoliticians = politicianRepository.findRandomPoliticians(politicianSize - topPoliticians.size());
+            topPoliticians.addAll(randomPoliticians);
+        }
+        List<PopularPoliticianResponse> popularPoliticians = topPoliticians.stream().map(PopularPoliticianResponse::entityToDto).collect(Collectors.toList());
+
+        // 인기 게시글 조회
+        List<Post> topPosts = postRepository.findByLikeCountGreaterThanOrderByLikeCountDesc(0, PageRequest.of(0, postSize));
+        List<PopularPostResponse> popularPosts = topPosts.stream().map(PopularPostResponse::entityToDto).collect(Collectors.toList());
+
+        return new GetHomeResponse(popularPoliticians, popularPosts);
+    }
 }

--- a/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
+++ b/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -33,8 +34,7 @@ public class HomeService {
         // 인기 정치인 조회
         List<Politician> topPoliticians = watchListRepository.findTopPoliticians(PageRequest.of(0, politicianSize));
         if(topPoliticians.size() < politicianSize){ // 부족할 경우 랜덤하게 선택된 정치인을 추가
-            List<Politician> randomPoliticians = politicianRepository.findRandomPoliticians(politicianSize - topPoliticians.size());
-            topPoliticians.addAll(randomPoliticians);
+            addRandomPoliticians(politicianSize, topPoliticians);
         }
         List<PopularPoliticianResponse> popularPoliticians = topPoliticians.stream().map(PopularPoliticianResponse::entityToDto).collect(Collectors.toList());
 
@@ -43,5 +43,22 @@ public class HomeService {
         List<PopularPostResponse> popularPosts = topPosts.stream().map(PopularPostResponse::entityToDto).collect(Collectors.toList());
 
         return new GetHomeResponse(popularPoliticians, popularPosts);
+    }
+
+    private void addRandomPoliticians(int politicianSize, List<Politician> topPoliticians) {
+        log.info("정치인 수가 충분하지 않아 {}명만 반환됨", topPoliticians.size());
+
+        Set<Long> existingIds = topPoliticians.stream()
+                .map(Politician::getId)
+                .collect(Collectors.toSet());
+
+        List<Politician> randomPoliticians = politicianRepository.findRandomPoliticians(politicianSize * 2);
+
+        List<Politician> additionalData = randomPoliticians.stream()
+                .filter(politician -> !existingIds.contains(politician))
+                .limit(politicianSize - topPoliticians.size())
+                .collect(Collectors.toList());
+
+        topPoliticians.addAll(additionalData);
     }
 }

--- a/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
+++ b/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
@@ -1,0 +1,9 @@
+package com.runningmate.server.domain.home.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class HomeService {
+}

--- a/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
+++ b/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
@@ -26,6 +26,10 @@ public class HomeService {
     public GetHomeResponse getData(final int politicianSize, final int postSize) {
         log.info("[getData]");
 
+        if (politicianSize < 0 || postSize < 0) {
+           throw new IllegalArgumentException("조회할 데이터의 수는 음수일 수 없습니다.");
+        }
+
         // 인기 정치인 조회
         List<Politician> topPoliticians = watchListRepository.findTopPoliticians(PageRequest.of(0, politicianSize));
         if(topPoliticians.size() < politicianSize){ // 부족할 경우 랜덤하게 선택된 정치인을 추가

--- a/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
+++ b/src/main/java/com/runningmate/server/domain/home/service/HomeService.java
@@ -55,7 +55,7 @@ public class HomeService {
         List<Politician> randomPoliticians = politicianRepository.findRandomPoliticians(politicianSize * 2);
 
         List<Politician> additionalData = randomPoliticians.stream()
-                .filter(politician -> !existingIds.contains(politician))
+                .filter(politician -> !existingIds.contains(politician.getId()))
                 .limit(politicianSize - topPoliticians.size())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/runningmate/server/domain/politicians/repository/PoliticianRepository.java
+++ b/src/main/java/com/runningmate/server/domain/politicians/repository/PoliticianRepository.java
@@ -29,7 +29,6 @@ public interface PoliticianRepository extends JpaRepository<Politician, Long> {
 
     @Query(value = """
         SELECT * FROM politician
-        WHERE imageUrl IS NOT NULL
         ORDER BY RAND()
         LIMIT :size
     """, nativeQuery = true)

--- a/src/main/java/com/runningmate/server/domain/politicians/repository/PoliticianRepository.java
+++ b/src/main/java/com/runningmate/server/domain/politicians/repository/PoliticianRepository.java
@@ -26,4 +26,12 @@ public interface PoliticianRepository extends JpaRepository<Politician, Long> {
 
     @Query("SELECT DISTINCT p.party FROM Politician p")
     List<String> findAllParties();
+
+    @Query(value = """
+        SELECT * FROM politician
+        WHERE imageUrl IS NOT NULL
+        ORDER BY RAND()
+        LIMIT :size
+    """, nativeQuery = true)
+    List<Politician> findRandomPoliticians(@Param("size") int size);
 }

--- a/src/main/java/com/runningmate/server/domain/watch/model/UserWatchListId.java
+++ b/src/main/java/com/runningmate/server/domain/watch/model/UserWatchListId.java
@@ -5,13 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 @Embeddable
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserWatchListId {
+public class UserWatchListId implements Serializable {
     private Long userId;
     private Long politicianId;
 

--- a/src/main/java/com/runningmate/server/domain/watch/repository/WatchListRepository.java
+++ b/src/main/java/com/runningmate/server/domain/watch/repository/WatchListRepository.java
@@ -1,8 +1,11 @@
 package com.runningmate.server.domain.watch.repository;
 
+import com.runningmate.server.domain.politicians.model.Politician;
 import com.runningmate.server.domain.watch.model.UserWatchList;
 import com.runningmate.server.domain.watch.model.UserWatchListId;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +16,12 @@ public interface WatchListRepository extends JpaRepository<UserWatchList, UserWa
     // 특정 정치인을 특정 유저가 지켜보는지 여부
     boolean existsById(UserWatchListId id);
     List<UserWatchList> findByUser_Id(Long userId);
+
+    @Query("""
+        select w.politician
+        from UserWatchList w
+        group by w.politician
+        order by count(w.politician) desc
+    """)
+    List<Politician> findTopPoliticians(Pageable pageable);
 }

--- a/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/runningmate/server/global/config/SecurityConfig.java
@@ -59,8 +59,8 @@ public class SecurityConfig {
                     authorize
                             .requestMatchers(
                                     "/edit/preference", "/auth/login", "/users/create", "/users/update",
-                                    "/calendar/schedules/**", "/elections/*/candidates",
-                                    "/politicians/*/detail", "/news", "/", "/politicians", "/parties"
+                                    "/calendar/schedules/**", "/elections/*/candidates", "/politicians/*/detail",
+                                    "/news", "/", "/politicians", "/parties", "/home"
                             ).permitAll()
                             .requestMatchers(SWAGGER_ENDPOINTS).permitAll();
 


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #96

## 작업 내용 📝
- 홈화면 조회 API를 구현했습니다
- 복합키 클래스 UserWatchListId가 Serializable을 구현하지 않았다는 점을 발견해서 수정했습니다

## 미해결 작업😅
- 없습니다

## 전달사항 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 홈 엔드포인트(/home) 추가 및 공개 접근 허용
  * 인기 정치인 및 인기 게시글 정보를 제공하는 홈 API 도입
  * 인기 정치인, 인기 게시글 응답 DTO 신설 및 변환 기능 추가
  * 인기 정치인 상위 조회 및 랜덤 추출 기능 추가

* **기능 개선**
  * 인기 게시글 조회 시 페이징 처리로 유연성 향상
  * 인기 정치인, 게시글 조회 로직 개선(워치리스트, 랜덤 추출 등)

* **버그 수정**
  * 복합키 클래스에 직렬화 기능 추가(사용자 워치리스트)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->