### PR TITLE
[Fix] 게시글 목록 조회에서 검색 기능 수정

### DIFF
--- a/src/main/java/com/runningmate/server/domain/community/service/PostService.java
+++ b/src/main/java/com/runningmate/server/domain/community/service/PostService.java
@@ -90,7 +90,7 @@ public class PostService {
                     .collect(Collectors.toList());
 
         return new GetPostsResponse(summarys,
-                summarys.get(summarys.size() - 1).postId(),
+                summarys.size() > 0 ? summarys.get(summarys.size() - 1).postId() : 0,
                 hasNext);
     }
 

--- a/src/test/java/com/runningmate/server/domain/community/controller/PostControllerTest.java
+++ b/src/test/java/com/runningmate/server/domain/community/controller/PostControllerTest.java
@@ -116,6 +116,47 @@ class PostControllerTest {
     }
 
     @Test
+    void givenFourPostsContainingKeyword_whenGetPosts_thenReturnFourPosts() throws Exception {
+        // given
+        User user = userService.createUser("user1", "pass", "작성자", "asdf@asdf");
+
+        final String KEYWORD = "keyword";
+        final String NOT_A_KEYWORD = "test";
+
+        IntStream.rangeClosed(1, 2).forEach(i ->{
+            createPostWithTitleAndContent(user, KEYWORD, NOT_A_KEYWORD);
+            createPostWithTitleAndContent(user, NOT_A_KEYWORD, KEYWORD);
+        });
+        IntStream.rangeClosed(1, 10).forEach(i ->{
+            createPostWithTitleAndContent(user, NOT_A_KEYWORD, NOT_A_KEYWORD);
+        });
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        ResultActions actions = mockMvc.perform(get("/posts?keyword=" + KEYWORD));
+
+        // then
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts.length()").value(4))
+                .andExpect(jsonPath("$.data.hasMore").value(false));
+    }
+
+    private Post createPostWithTitleAndContent(User user, String title, String content) {
+        Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .writer(user)
+                .build();
+
+        postRepository.save(post);
+
+        return post;
+    }
+
+    @Test
     void givenTwoReplies_whenGetPostComments_thenReturnTwoReplies() throws Exception {
         // given
         User postWriter = userService.createUser("user1", "pass", "게시글작성자", "asdf@asdf");


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #98

## 작업 내용 📝
- 게시글 목록 조회에서 키워드를 가지고 검색할 때 서버 내부 오류가 발생하는 버그를 수정했습니다.

## 미해결 작업😅
- 없습니다

## 전달사항 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 게시글 목록 조회 시, 게시글이 없을 경우 발생할 수 있는 오류를 방지하였습니다.

* **테스트**
  * 키워드로 게시글을 검색할 때, 제목이나 내용에 해당 키워드가 포함된 게시글만 정확히 반환되는지 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->