### PR TITLE
[Feat] 마이페이지 조회 기능 구현

### DIFF
--- a/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
@@ -21,5 +21,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByLikeCountGreaterThanOrderByLikeCountDesc(int likeCount, Pageable pageable);
 
-    long countByWriterId(long writerId);
+    long countByWriterId(Long writerId);
 }

--- a/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
@@ -20,4 +20,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findWithKeywordAndCursor(@Param("keyword")String keyword, @Param("lastId") Long lastId, Pageable pageable);
 
     List<Post> findByLikeCountGreaterThanOrderByLikeCountDesc(int likeCount, Pageable pageable);
+
+    long countByWriterId(long writerId);
 }

--- a/src/main/java/com/runningmate/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/runningmate/server/domain/user/controller/UserController.java
@@ -13,18 +13,19 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
+@RequestMapping("users")
 @RestController
 public class UserController {
     private final UserService userService;
 
-    @PostMapping("/users/create")
+    @PostMapping("/create")
     public BaseResponse<Void> createUser(@RequestBody @Valid CreateUserRequest request){
         log.info("[postUser] request = {}", request);
         userService.createUser(request.getUsername(), request.getPassword(), request.getNickname(), request.getEmail());
         return new BaseResponse<>(null);
     }
 
-    @PostMapping("/users/update")
+    @PostMapping("/update")
     public BaseResponse<Void> updateUser(@RequestParam("prevId") Long prevId, @RequestBody UpdateUserRequest req){
         log.info("[updateUser] prevId = {}", prevId);
         userService.updateUser(prevId, req.getPassword(), req.getNickname());
@@ -38,7 +39,7 @@ public class UserController {
         return new BaseResponse<>(null);
     }
 
-    @GetMapping("users")
+    @GetMapping
     public BaseResponse<GetMyPageResponse> getMyPage(@LoginUserId Long userId){
         log.info("[getMyPage] userId = {}", userId);
         return new BaseResponse<>(userService.findUserDataForMyPage(userId));

--- a/src/main/java/com/runningmate/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/runningmate/server/domain/user/controller/UserController.java
@@ -1,9 +1,11 @@
 package com.runningmate.server.domain.user.controller;
 
 import com.runningmate.server.domain.user.dto.CreateUserRequest;
+import com.runningmate.server.domain.user.dto.GetMyPageResponse;
 import com.runningmate.server.domain.user.dto.UpdateUserRequest;
 import com.runningmate.server.domain.user.service.UserService;
 import com.runningmate.server.global.common.response.BaseResponse;
+import com.runningmate.server.global.jwt.LoginUserId;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,5 +36,11 @@ public class UserController {
         log.info(req.getPartyOfInterest());
         userService.updatePreference(prevId, req.getPartyOfInterest(), req.getPoliticianOfInterest());
         return new BaseResponse<>(null);
+    }
+
+    @GetMapping("users")
+    public BaseResponse<GetMyPageResponse> getMyPage(@LoginUserId Long userId){
+        log.info("[getMyPage] userId = {}", userId);
+        return new BaseResponse<>(userService.findUserDataForMyPage(userId));
     }
 }

--- a/src/main/java/com/runningmate/server/domain/user/dto/GetMyPageResponse.java
+++ b/src/main/java/com/runningmate/server/domain/user/dto/GetMyPageResponse.java
@@ -1,0 +1,25 @@
+package com.runningmate.server.domain.user.dto;
+
+import com.runningmate.server.domain.user.model.User;
+import com.runningmate.server.domain.watch.dto.PoliticianWithWatchCount;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GetMyPageResponse(
+        String nickname,
+        String partyOfInterest,
+        String politicianOfInterest,
+        Long postCount,
+        List<WatchingPoliticianResponse> watchingPoliticians
+) {
+
+    public static GetMyPageResponse from(User user, long postCount, List<PoliticianWithWatchCount> politiciansWithWatchCount){
+        List<WatchingPoliticianResponse> watchingPoliticians = politiciansWithWatchCount.stream()
+                .map(dto -> dto.politician())
+                .map(WatchingPoliticianResponse::entityToDto)
+                .collect(Collectors.toList());
+
+        return new GetMyPageResponse(user.getNickname(), user.getPartyOfInterest(), user.getPoliticianOfInterest(), postCount, watchingPoliticians);
+    }
+}

--- a/src/main/java/com/runningmate/server/domain/user/dto/WatchingPoliticianResponse.java
+++ b/src/main/java/com/runningmate/server/domain/user/dto/WatchingPoliticianResponse.java
@@ -1,0 +1,12 @@
+package com.runningmate.server.domain.user.dto;
+
+import com.runningmate.server.domain.politicians.model.Politician;
+
+public record WatchingPoliticianResponse(
+        String party,
+        String name
+) {
+    public static WatchingPoliticianResponse entityToDto(Politician entity){
+        return new WatchingPoliticianResponse(entity.getParty(), entity.getName());
+    }
+}

--- a/src/main/java/com/runningmate/server/domain/user/service/UserService.java
+++ b/src/main/java/com/runningmate/server/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.runningmate.server.domain.user.repository.UserRepository;
 import com.runningmate.server.domain.watch.dto.PoliticianWithWatchCount;
 import com.runningmate.server.domain.watch.repository.WatchListRepository;
 import com.runningmate.server.global.common.exception.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -19,6 +20,7 @@ import static com.runningmate.server.global.common.response.status.BaseException
 
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class UserService {
     private final UserRepository userRepository;

--- a/src/main/java/com/runningmate/server/domain/user/service/UserService.java
+++ b/src/main/java/com/runningmate/server/domain/user/service/UserService.java
@@ -1,18 +1,29 @@
 package com.runningmate.server.domain.user.service;
 
+import com.runningmate.server.domain.community.repository.PostRepository;
+import com.runningmate.server.domain.user.dto.GetMyPageResponse;
 import com.runningmate.server.domain.user.exception.SameUserExistsException;
 import com.runningmate.server.domain.user.model.User;
 import com.runningmate.server.domain.user.repository.UserRepository;
+import com.runningmate.server.domain.watch.dto.PoliticianWithWatchCount;
+import com.runningmate.server.domain.watch.repository.WatchListRepository;
+import com.runningmate.server.global.common.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.SAME_USERNAME_EXISTS;
-import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.SAME_USER_EMAIL_EXISTS;
+import java.util.List;
 
+import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.*;
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final WatchListRepository watchListRepository;
 
     public User createUser(String username, String password, String nickname, String email) {
         if(validateUsername(username)){
@@ -62,5 +73,20 @@ public class UserService {
 
     private boolean validateEmail(String email) {
         return userRepository.existsByEmail(email);
+    }
+
+    public GetMyPageResponse findUserDataForMyPage(Long userId) {
+        log.info("[findUserDataForMyPage] userId={}", userId);
+
+        // 회원 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        // 게시글 개수 조회
+        long postCount = postRepository.countByWriterId(userId);
+
+        // 지켜보는 정치인 조회
+        List<PoliticianWithWatchCount> politiciansWithWatchCount = watchListRepository.findTopPoliticiansByUserId(userId, PageRequest.of(0, 3));
+
+        return GetMyPageResponse.from(user, postCount, politiciansWithWatchCount);
     }
 }

--- a/src/main/java/com/runningmate/server/domain/watch/dto/PoliticianWithWatchCount.java
+++ b/src/main/java/com/runningmate/server/domain/watch/dto/PoliticianWithWatchCount.java
@@ -1,0 +1,9 @@
+package com.runningmate.server.domain.watch.dto;
+
+import com.runningmate.server.domain.politicians.model.Politician;
+
+public record PoliticianWithWatchCount(
+        Politician politician,
+        Long count
+) {
+}

--- a/src/main/java/com/runningmate/server/domain/watch/repository/WatchListRepository.java
+++ b/src/main/java/com/runningmate/server/domain/watch/repository/WatchListRepository.java
@@ -1,11 +1,13 @@
 package com.runningmate.server.domain.watch.repository;
 
 import com.runningmate.server.domain.politicians.model.Politician;
+import com.runningmate.server.domain.watch.dto.PoliticianWithWatchCount;
 import com.runningmate.server.domain.watch.model.UserWatchList;
 import com.runningmate.server.domain.watch.model.UserWatchListId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -24,4 +26,13 @@ public interface WatchListRepository extends JpaRepository<UserWatchList, UserWa
         order by count(w.politician) desc
     """)
     List<Politician> findTopPoliticians(Pageable pageable);
+
+    @Query("""
+        select new com.runningmate.server.domain.watch.dto.PoliticianWithWatchCount(w.politician, count(w))
+        from UserWatchList w
+        where w.user.id = :userId
+        group by w.politician
+        order by count(w) desc
+    """)
+    List<PoliticianWithWatchCount> findTopPoliticiansByUserId(@Param("userId") long userId, Pageable pageable);
 }

--- a/src/main/java/com/runningmate/server/domain/watch/repository/WatchListRepository.java
+++ b/src/main/java/com/runningmate/server/domain/watch/repository/WatchListRepository.java
@@ -34,5 +34,5 @@ public interface WatchListRepository extends JpaRepository<UserWatchList, UserWa
         group by w.politician
         order by count(w) desc
     """)
-    List<PoliticianWithWatchCount> findTopPoliticiansByUserId(@Param("userId") long userId, Pageable pageable);
+    List<PoliticianWithWatchCount> findTopPoliticiansByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/test/java/com/runningmate/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/runningmate/server/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,168 @@
+package com.runningmate.server.domain.user.controller;
+
+import com.runningmate.server.domain.community.model.Post;
+import com.runningmate.server.domain.community.repository.PostRepository;
+import com.runningmate.server.domain.news.schedule.NewsScheduler;
+import com.runningmate.server.domain.news.service.NewsService;
+import com.runningmate.server.domain.politicians.init.PoliticianInitializer;
+import com.runningmate.server.domain.politicians.model.Politician;
+import com.runningmate.server.domain.politicians.repository.PoliticianRepository;
+import com.runningmate.server.domain.user.model.User;
+import com.runningmate.server.domain.user.service.UserService;
+import com.runningmate.server.domain.watch.service.WatchListService;
+import com.runningmate.server.global.jwt.JwtUtil;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NewsScheduler newsScheduler; // 테스트에서 제외하기 위함
+
+    @MockBean
+    private NewsService newsService;  // 테스트에서 제외하기 위함
+
+    @MockBean
+    private PoliticianInitializer initializer; // 테스트에서 제외하기 위함
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private WatchListService watchListService;
+
+    @Autowired
+    private PoliticianRepository politicianRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+
+    @Test
+    void givenUserWithTwoWatchingPoliticians_getUsers_thenReturnTwoWatchingPoliticians() throws Exception {
+        // given
+        User user = userService.createUser("user1", "pass", "작성자", "asdf@asdf");
+
+        IntStream.rangeClosed(1, 2).forEach(i -> {
+            Politician politician = createPolitician("정치인" + i, "정정당당");
+            watchListService.followPolitician(user.getId(), politician.getId());
+        });
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        String token = jwtUtil.generateAccessToken(user.getId(), user.getUsername());
+
+        ResultActions actions = mockMvc.perform(get("/users")
+                .header("Authorization", "Bearer " + token));
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.watchingPoliticians.length()").value(2))
+                .andExpect(jsonPath("$.data.postCount").value(0))
+                .andExpect(jsonPath("$.data.partyOfInterest").isEmpty())
+                .andExpect(jsonPath("$.data.politicianOfInterest").isEmpty());
+    }
+
+    private Politician createPolitician(String name, String party) {
+        Politician build = Politician.builder()
+                .name(name)
+                .party(party)
+                .build();
+
+        return politicianRepository.save(build);
+    }
+
+    @Test
+    void givenUserWithInterestingPartyAndPolitician_getUsers_thenReturnInterestingPartyAndPolitician() throws Exception {
+        // given
+        User user = userService.createUser("user1", "pass", "작성자", "asdf@asdf");
+
+        final String PARTY = "성심당";
+        final String POLITICIAN = "망고시루";
+
+        userService.updatePreference(user.getId(), PARTY, POLITICIAN);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        String token = jwtUtil.generateAccessToken(user.getId(), user.getUsername());
+
+        ResultActions actions = mockMvc.perform(get("/users")
+                .header("Authorization", "Bearer " + token));
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.watchingPoliticians.length()").value(0))
+                .andExpect(jsonPath("$.data.postCount").value(0))
+                .andExpect(jsonPath("$.data.partyOfInterest").value(PARTY))
+                .andExpect(jsonPath("$.data.politicianOfInterest").value(POLITICIAN));
+    }
+
+    @Test
+    void givenUserWroteTwoPosts_getUsers_thenPostCountIsTwo() throws Exception {
+        // given
+        User user = userService.createUser("user1", "pass", "작성자", "asdf@asdf");
+
+        IntStream.rangeClosed(1, 2).forEach(i -> {
+            createPostWithTitleAndContent(user, "제목", "내용");
+        });
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        String token = jwtUtil.generateAccessToken(user.getId(), user.getUsername());
+
+        ResultActions actions = mockMvc.perform(get("/users")
+                .header("Authorization", "Bearer " + token));
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.watchingPoliticians.length()").value(0))
+                .andExpect(jsonPath("$.data.postCount").value(2))
+                .andExpect(jsonPath("$.data.partyOfInterest").isEmpty())
+                .andExpect(jsonPath("$.data.politicianOfInterest").isEmpty());
+    }
+
+    private Post createPostWithTitleAndContent(User user, String title, String content) {
+        Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .writer(user)
+                .build();
+
+        postRepository.save(post);
+
+        return post;
+    }
+}


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #100

## 작업 내용 📝
- 마이페이지 조회 기능을 구현했습니다

## 미해결 작업😅
- 없습니다

## 전달사항 📢
- UserController에서 처리하는 요청의 엔드포인트가 users로 시작되도록 수정했습니다. 작업에 참고 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 현재 사용자의 프로필 정보를 조회하는 `/users` GET 엔드포인트가 추가되었습니다. 이 엔드포인트를 통해 닉네임, 관심 정당, 관심 정치인, 작성한 게시글 수, 그리고 사용자가 팔로우 중인 정치인 목록을 확인할 수 있습니다.
  * 사용자 프로필 데이터에 작성한 게시글 수와 팔로우 중인 정치인 목록이 포함되어 제공됩니다.

* **테스트**
  * 사용자 프로필 조회 기능에 대한 통합 테스트가 추가되어, 다양한 사용자 시나리오(팔로우 정치인, 관심 정당/정치인, 게시글 수 등)에 대한 응답의 정확성이 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->