### PR TITLE
[Feat] 내가 쓴 커뮤니티 글 목록 조회

### DIFF
--- a/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
@@ -31,5 +31,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             where (:lastId is null or p.id < :lastId) and p.writer.id = :userId
             order by p.id desc
     """)
-    List<Post> findUserPostsByCursor(@Param("userId") Long userId, @Param("lastId") Long lastId, PageRequest of);
+    List<Post> findUserPostsByCursor(@Param("userId") Long userId, @Param("lastId") Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/runningmate/server/domain/community/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.runningmate.server.domain.community.repository;
 
 import com.runningmate.server.domain.community.model.Post;
+import com.runningmate.server.domain.user.model.User;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +24,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByLikeCountGreaterThanOrderByLikeCountDesc(int likeCount, Pageable pageable);
 
     long countByWriterId(Long writerId);
+
+
+    @Query("""
+            select p from Post p 
+            where (:lastId is null or p.id < :lastId) and p.writer.id = :userId
+            order by p.id desc
+    """)
+    List<Post> findUserPostsByCursor(@Param("userId") Long userId, @Param("lastId") Long lastId, PageRequest of);
 }

--- a/src/main/java/com/runningmate/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/runningmate/server/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.runningmate.server.domain.user.controller;
 
 import com.runningmate.server.domain.user.dto.CreateUserRequest;
 import com.runningmate.server.domain.user.dto.GetMyPageResponse;
+import com.runningmate.server.domain.user.dto.GetMyPostsResponse;
 import com.runningmate.server.domain.user.dto.UpdateUserRequest;
 import com.runningmate.server.domain.user.service.UserService;
 import com.runningmate.server.global.common.response.BaseResponse;
@@ -43,5 +44,11 @@ public class UserController {
     public BaseResponse<GetMyPageResponse> getMyPage(@LoginUserId Long userId){
         log.info("[getMyPage] userId = {}", userId);
         return new BaseResponse<>(userService.findUserDataForMyPage(userId));
+    }
+
+    @GetMapping("/posts")
+    public BaseResponse<GetMyPostsResponse> getMyPosts(@LoginUserId Long userId, @RequestParam(required = false) Long lastId){
+        log.info("[getMyPosts] userId = {} lastId = {}", userId, lastId);
+        return new BaseResponse<>(userService.findUserPostsByCursor(userId, lastId, 20));
     }
 }

--- a/src/main/java/com/runningmate/server/domain/user/dto/GetMyPostsResponse.java
+++ b/src/main/java/com/runningmate/server/domain/user/dto/GetMyPostsResponse.java
@@ -1,0 +1,12 @@
+package com.runningmate.server.domain.user.dto;
+
+import com.runningmate.server.domain.community.dto.PostSummaryDto;
+
+import java.util.List;
+
+public record GetMyPostsResponse(
+        List<PostSummaryDto> posts,
+        Long lastId,
+        Boolean hasMore
+) {
+}

--- a/src/main/java/com/runningmate/server/domain/user/service/UserService.java
+++ b/src/main/java/com/runningmate/server/domain/user/service/UserService.java
@@ -105,7 +105,7 @@ public class UserService {
         // dto로 변환
         List<PostSummaryDto> summarys = posts.stream().map(PostSummaryDto::entityToDto).limit(size).collect(Collectors.toList());
         Long nextLastId = getLastId(summarys);
-        Boolean hasMore = summarys.size() > size;
+        Boolean hasMore = posts.size() > size;
 
         return new GetMyPostsResponse(summarys, nextLastId, hasMore);
     }

--- a/src/main/java/com/runningmate/server/domain/user/service/UserService.java
+++ b/src/main/java/com/runningmate/server/domain/user/service/UserService.java
@@ -1,7 +1,10 @@
 package com.runningmate.server.domain.user.service;
 
+import com.runningmate.server.domain.community.dto.PostSummaryDto;
+import com.runningmate.server.domain.community.model.Post;
 import com.runningmate.server.domain.community.repository.PostRepository;
 import com.runningmate.server.domain.user.dto.GetMyPageResponse;
+import com.runningmate.server.domain.user.dto.GetMyPostsResponse;
 import com.runningmate.server.domain.user.exception.SameUserExistsException;
 import com.runningmate.server.domain.user.model.User;
 import com.runningmate.server.domain.user.repository.UserRepository;
@@ -15,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.runningmate.server.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -90,5 +94,23 @@ public class UserService {
         List<PoliticianWithWatchCount> politiciansWithWatchCount = watchListRepository.findTopPoliticiansByUserId(userId, PageRequest.of(0, 3));
 
         return GetMyPageResponse.from(user, postCount, politiciansWithWatchCount);
+    }
+
+    public GetMyPostsResponse findUserPostsByCursor(Long userId, Long lastId, int size) {
+        log.info("[findUserPosts]");
+
+        // 사용자가 작성한 게시글을 조회
+        List<Post> posts = postRepository.findUserPostsByCursor(userId, lastId, PageRequest.of(0, size + 1));
+
+        // dto로 변환
+        List<PostSummaryDto> summarys = posts.stream().map(PostSummaryDto::entityToDto).limit(size).collect(Collectors.toList());
+        Long nextLastId = getLastId(summarys);
+        Boolean hasMore = summarys.size() > size;
+
+        return new GetMyPostsResponse(summarys, nextLastId, hasMore);
+    }
+
+    private static long getLastId(List<PostSummaryDto> summarys) {
+        return summarys.size() > 0 ? summarys.get(summarys.size() - 1).postId() : 0L;
     }
 }


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #106

## 작업 내용 📝
- 사용자가 쓴 커뮤니티 글 목록을 조회할 수 있는 API를 구현했습니다

## 미해결 작업😅
- 없습니다

## 전달사항 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 본인이 작성한 게시글 목록을 페이지네이션 방식으로 조회할 수 있는 새로운 API 엔드포인트(`/users/posts`)가 추가되었습니다.
  * 게시글 목록은 커서 기반 페이지네이션을 지원하며, 다음 페이지가 있는지 여부와 마지막 게시글 ID 정보를 함께 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->