### PR TITLE
[Feat] 공공데이터로부터 조회할 선거후보자의 범위를 조정

### DIFF
--- a/src/main/java/com/runningmate/server/domain/politicians/client/CandidateApiClient.java
+++ b/src/main/java/com/runningmate/server/domain/politicians/client/CandidateApiClient.java
@@ -55,7 +55,7 @@ public class CandidateApiClient {
                     .toEntity(String.class);
 
             String responseBody = responseEntity.getBody();
-            log.info("candidate. {}", responseBody);
+//            log.info("candidate. {}", responseBody);
 
             // Json을 객체로 변환
             //CandidateApiResponse response2 = getCandidateApiResponse(responseBody);
@@ -70,8 +70,10 @@ public class CandidateApiClient {
             }
 
 
-            log.info("{}", responseEntity);
+//            log.info("{}", responseEntity);
         }
+
+//        log.info("results size = {}", results.size());
 
         return results;
     }
@@ -84,9 +86,9 @@ public class CandidateApiClient {
             List<CandidateItem> candidateItems = requestCndaInfo(electionId, electionType);
             allCandidateItems.addAll(candidateItems);
 
-            //log.info("{}", candidateItems.size()); //699
+            log.info("{} 선거에서 {}개 데이터 파싱", electionId, candidateItems.size()); //699
         }
-        //log.info("itemSize {}", allCandidateItems.size()); // 953
+        log.info("총 후보자 수 {}", allCandidateItems.size()); // 953
         return allCandidateItems;
     }
 }

--- a/src/main/java/com/runningmate/server/domain/politicians/client/ElectionCodeApiClient.java
+++ b/src/main/java/com/runningmate/server/domain/politicians/client/ElectionCodeApiClient.java
@@ -52,7 +52,7 @@ public class ElectionCodeApiClient {
                     .toEntity(String.class);
 
             responseBody = responseEntity.getBody();
-            log.info(responseBody);
+//            log.info(responseBody);
 
             // Json 파싱
             // JSON을 Java 객체로 변환

--- a/src/main/java/com/runningmate/server/domain/politicians/client/NationalAssemblyApiClient.java
+++ b/src/main/java/com/runningmate/server/domain/politicians/client/NationalAssemblyApiClient.java
@@ -72,13 +72,15 @@ public class NationalAssemblyApiClient {
             // 올바른 rowList 가져오기 & Null 체크
             if (response.getAllNaMember().size() > 1 && response.getAllNaMember().get(1).getRowList() != null) {
                 results.addAll(response.getAllNaMember().get(1).getRowList());
-                //log.info("result size {}", results.size());
+//                log.info("result size {}", results.size());
             } else {
                 break;
             }
 
 
         }
+
+        log.info("results size = {}", results.size());
 
         return results;
     }

--- a/src/main/java/com/runningmate/server/domain/politicians/service/NationalAssemblyService.java
+++ b/src/main/java/com/runningmate/server/domain/politicians/service/NationalAssemblyService.java
@@ -46,6 +46,8 @@ public class NationalAssemblyService {
 
         List<Politician> politicians = findPoliticiansByBirthdayAndParty(birthdays, names);
 
+        log.info("이미지를 업데이트할 국회의원 수 = {}", politicians.size());
+
         // 3. 기존 db에 생일과 소속당을 기반으로 국회의원 imgUrl을 추가시킨다.
         updateImageUrl(politicians, naRows);
         checkImageUrls(); // 디버깅용
@@ -55,8 +57,8 @@ public class NationalAssemblyService {
     public void checkImageUrls() {
         List<Politician> politicians = politicianRepository.findAll();
         for (Politician politician : politicians) {
-            log.info("이름: {}, 정당: {}, 이미지 URL: {}",
-                    politician.getName(), politician.getParty(), politician.getImageUrl());
+//            log.info("이름: {}, 정당: {}, 이미지 URL: {}",
+//                    politician.getName(), politician.getParty(), politician.getImageUrl());
         }
     }
 

--- a/src/main/java/com/runningmate/server/domain/politicians/service/PoliticianInfoService.java
+++ b/src/main/java/com/runningmate/server/domain/politicians/service/PoliticianInfoService.java
@@ -42,7 +42,7 @@ public class PoliticianInfoService {
         log.info("response {}", response.size());
 
         // 필터링
-        List<ElectionCodeItem> filteredByNationalAndYear = ElectionCodeUtil.getFilteredElectionCodeItems(response, 2024, "국회의원");
+        List<ElectionCodeItem> filteredByNationalAndYear = ElectionCodeUtil.getFilteredElectionCodeItems(response, 2010, "");
         log.info("filteredByNationalAndYear {}", filteredByNationalAndYear.size());
 
         // Election 저장 (중복 방지)
@@ -52,7 +52,6 @@ public class PoliticianInfoService {
 
         // 선거 Id와 선거 종류 코드로 후보자 정보 가져오기
         List<CandidateItem> allCandidateItems = candidateApiClient.fetchCandidateInfo(filteredByNationalAndYear);
-        log.info("allCandidateItems {}", allCandidateItems.size());
 
         // DB 저장
         for (CandidateItem allCandidateItem : allCandidateItems) {


### PR DESCRIPTION
## 관련 이슈 🛠
- closed #114 

## 작업 내용 📝
- 공공데이터로부터 조회할 선거후보자의 범위를 조정하다

## 미해결 작업😅
- 없습니다

## 전달사항 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 일부 상세 로그 출력을 비활성화하거나 요약 로그로 변경하여 로그 노이즈를 줄였습니다.
  * 특정 메서드에서 처리 결과 요약 로그를 추가하거나, 반복 중 중간 로그를 최종 결과 로그로 대체하였습니다.

* **기타**
  * 선거 코드 필터 기준이 2024년/국회의원에서 2010년/전체로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->